### PR TITLE
Pull Request: Improve PDF File Status Handling and Batch Rename Logic

### DIFF
--- a/src/utils/dotify.ts
+++ b/src/utils/dotify.ts
@@ -1,5 +1,11 @@
 import { FileItem } from "../types";
 
+const titleCase = (title: string): string => {
+    const titleWords = title.split(' ');
+    const newTitle = titleWords.map( (word: string) => word.charAt(0).toUpperCase() + word.slice(1) );
+    return newTitle.join(' ');
+}
+
 const removeExtension = (title: string) => {
     const posFileExtension = title.search(/(\.pdf)$/i);
     return posFileExtension !== -1 ? title.substring(0, posFileExtension) : title;  
@@ -87,7 +93,7 @@ const capitalizeAB = (
 };
 
 const buildFullTitle = (prodTitle: string, epTitle: string, epNumber: string): string => {
-    return `${prodTitle}   ${epTitle}  ${epNumber}`
+    return `${prodTitle.toUpperCase()}   ${titleCase(epTitle)}  ${epNumber}`
 };
 
 const dotify = (
@@ -133,7 +139,7 @@ const dotify = (
     }
 
 
-    const newTitle = `${prodTitle}   ${epTitle}  ${epNumber}`;
+    const newTitle = buildFullTitle(prodTitle, epTitle, epNumber);
     return [newTitle, status];
 };
 

--- a/src/utils/fileHelpers.ts
+++ b/src/utils/fileHelpers.ts
@@ -34,7 +34,8 @@ export const checkForDuplicates = (files: FileItem[]): FileItem[] => {
 };
 
 export const applyCueSheetConvention = (filename: string): [string, fileStatus] => {
-  return dotifyTitle(filename);
+  const cleanTitle =  dotifyTitle(filename);
+  return cleanTitle;
 };
 
 export const applySearchReplace = (
@@ -52,7 +53,7 @@ export const applySearchReplace = (
       if (rule.replaceWith === 'CUE_SHEET_TEMPLATE') {
         const results = applyCueSheetConvention(newName);
         newName = Array.isArray(results) ? results[0] : results;
-        if (newName !== file.currentName) {
+        if (newName !== file.currentName && results[1] !== 'dotified') {
           status = 'modified';
         } else {
           status = Array.isArray(results) ? results[1] as FileItem['status'] : file.status;


### PR DESCRIPTION
Closes #5

## Summary
This PR refines the logic for PDF file status assignment and batch renaming in the file manager, ensure that production titles are returned in uppercase and episode titles are returned in title case.

## Changes
- Fixed issue in logic branching where the titles could bypass the casing logic.
- Fixed issue related to status `dotified` not appearing correctly.

## Motivation
- Fixes an issue where files with special statuses could be incorrectly overwritten or excluded from batch operations and downloads.
- Addresses issue #5.

## Testing
- Manually tested batch renaming with various rules, including cue sheet templates.
- Verified that files with custom statuses are handled and downloaded as expected.
- Checked that invalid and duplicate files are still excluded from downloads.